### PR TITLE
Fix: Caching problems with newer providers

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1337,6 +1337,18 @@ sub update_nics {
         if (@hosts) {
             $0 = sprintf("%s - updating %s", $program, join(',', @hosts));
             &$update(@hosts);
+
+            # Backwards compatibility:
+            # If we only have 'use', we set 'wantipv4' or 'wantipv6' depending on the IP type of
+            # 'wantip'. Newer provider implementations such as cloudflare only check 'wantipv*'
+            # and set 'status-ipv*' accordingly, ignoring 'wantip' and 'status'.
+            # For these we then load back the 'status' from 'status-ipv*' to ensure correct
+            # caching and updating behaviour.
+            foreach my $h (@hosts) {
+                $config{$h}{'status'} //= $config{$h}{'status-ipv4'};
+                $config{$h}{'status'} //= $config{$h}{'status-ipv6'};
+            }
+
             runpostscript(join ' ', keys %ipsv4, keys %ipsv6);
         }
     }

--- a/ddclient.in
+++ b/ddclient.in
@@ -3696,6 +3696,25 @@ sub header_ok {
     }
     return $ok;
 }
+
+######################################################################
+## DDNS providers
+#  A DDNS provider consists of an example function, the update
+#  function, and an optional updateable function.
+#
+#  The example function simply returns a string for the help message,
+#  explaining how to configure the provider
+#
+#  The update function performs the actual record update.
+#  It receives an array of hosts as its argument.
+#
+#  The updateable function allows a provider implementation to force
+#  an update even if ddclient has itself determined no update is
+#  necessary. The function shall return 1 if an update should be
+#  performed, else 0.
+######################################################################
+
+
 ######################################################################
 ## nic_dyndns1_examples
 ######################################################################

--- a/ddclient.in
+++ b/ddclient.in
@@ -4747,7 +4747,8 @@ sub nic_easydns_update {
                 my ($status) = $line =~ /^(\S*)\b.*/;
                 my $h = shift @hosts;
 
-                $config{$h}{'status'} = $status;
+                $config{$h}{'status-ipv4'} = $status if $ipv4;
+                $config{$h}{'status-ipv6'} = $status if $ipv6;
                 if ($status eq 'NOERROR') {
                     $config{$h}{'ipv4'}  = $ipv4;
                     $config{$h}{'ipv6'}  = $ipv6;
@@ -7081,12 +7082,12 @@ sub nic_porkbun_update {
             );
             # No response, declare as failed
             if (!defined($reply) || !$reply) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv4'} = "bad";
                 failed("updating %s: Could not connect to porkbun.com.", $host);
                 next;
             }
             if (!header_ok($host, $reply)) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv4'} = "bad";
                 failed("updating %s: failed (%s)", $host, $reply);
                 next;
             }
@@ -7095,12 +7096,12 @@ sub nic_porkbun_update {
             $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
             my $response = eval { decode_json(${^MATCH}) };
             if (!defined($response)) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv4'} = "bad";
                 failed("%s -- Unexpected service response.", $host);
                 next;
             }
             if ($response->{status} ne 'SUCCESS') {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv4'} = "bad";
                 failed("%s -- Unexpected status. (status = %s)", $host, $response->{status});
                 next;
             }
@@ -7112,7 +7113,7 @@ sub nic_porkbun_update {
                 }
                 my $current_content = $records->[0]->{'content'};
                 if ($current_content eq $ipv4) {
-                    $config{$host}{'status'} = "good";
+                    $config{$host}{'status-ipv4'} = "good";
                     success("updating %s: skipped: IPv4 address was already set to %s.", $host, $ipv4);
                     next;
                 }
@@ -7144,11 +7145,11 @@ sub nic_porkbun_update {
                     failed("updating %s: failed (%s)", $host, $reply);
                     next;
                 }
-                $config{$host}{'status'} = "good";
+                $config{$host}{'status-ipv4'} = "good";
                 success("updating %s: good: IPv4 address set to %s", $host, $ipv4);
                 next;
             } else {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv4'} = "bad";
                 failed("updating %s: No applicable existing records.", $host);
                 next;
             }
@@ -7174,12 +7175,12 @@ sub nic_porkbun_update {
             );
             # No response, declare as failed
             if (!defined($reply) || !$reply) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv6'} = "bad";
                 failed("updating %s: Could not connect to porkbun.com.", $host);
                 next;
             }
             if (!header_ok($host, $reply)) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv6'} = "bad";
                 failed("updating %s: failed (%s)", $host, $reply);
                 next;
             }
@@ -7188,12 +7189,12 @@ sub nic_porkbun_update {
             $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
             my $response = eval { decode_json(${^MATCH}) };
             if (!defined($response)) {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv6'} = "bad";
                 failed("%s -- Unexpected service response.", $host);
                 next;
             }
             if ($response->{status} ne 'SUCCESS') {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv6'} = "bad";
                 failed("%s -- Unexpected status. (status = %s)", $host, $response->{status});
                 next;
             }
@@ -7205,7 +7206,7 @@ sub nic_porkbun_update {
                 }
                 my $current_content = $records->[0]->{'content'};
                 if ($current_content eq $ipv6) {
-                    $config{$host}{'status'} = "good";
+                    $config{$host}{'status-ipv6'} = "good";
                     success("updating %s: skipped: IPv6 address was already set to %s.", $host, $ipv6);
                     next;
                 }
@@ -7237,11 +7238,11 @@ sub nic_porkbun_update {
                     failed("updating %s: failed (%s)", $host, $reply);
                     next;
                 }
-                $config{$host}{'status'} = "good";
+                $config{$host}{'status-ipv6'} = "good";
                 success("updating %s: good: IPv6 address set to %s", $host, $ipv4);
                 next;
             } else {
-                $config{$host}{'status'} = "bad";
+                $config{$host}{'status-ipv6'} = "bad";
                 failed("updating %s: No applicable existing records.", $host);
                 next;
             }


### PR DESCRIPTION
This fixes the caching issues #3 of new providers such as Cloudflare not respecting the cache and updating at the daemon interval.

With this change we now have the following rules for providers (that want caching).
Old provider implementations shall:
- Read out `$config{$host}{'wantip'}` and process it.
- Set `$config{$host}{'status'}` to the result

New provider implementations shall:
- Read out `$config{$host}{'wantipv4'}` and process it.
- Set `$config{$host}{'status-ipv4'}` to the result:
- Read out `$config{$host}{'wantipv6'}` and process it.
- Set `$config{$host}{'status-ipv6'}` to the result
For all cases, the 'status*' result shall be set to "good" on success, a readable error otherwise - i.e. "bad" or "failed".
- Existing providers may still set `status`, but any modified/newly added ones shouldn't. With this fix, we now take care of setting it based on `status-ipv*` if its not set for backwards compatibility.

The configuration shall either:
- Contain the `use` parameter
  In this case, the provider functions will be called with `wantip` set, and (depending on the IP address type) either `wantipv4` or `wantipv6` set.
- Contain one or both of: `usev4`, `usev6`
  In this case, the provider functions will be called with `wantipv4` and/or `wantipv6` set. Additionally for backwards compatibility, `wantip` will be set to the value of `wantipv4` (if usev4 is present and valid).


---
Outstanding tasks:
- [x] Document provider rules for `nic_*_update()` functions
- [x] Document 'use*' legacy vs current behavior
- [x] Review providers for correct behavior against rules
- [x] Investigate whether easydns & porkbun are regressions (Fixed by updating them to new provider rules)

<details>
<summary>Current provider behavior</summary>

- dyndns1
delete wantip
set status

- dyndns2
delete wantipv*
set status, status-ipv4, status-ipv6

- dnsexit2
delete wantip
set status

- noip
delete wantip
set status

- dslreports1
delete wantip
set status

- domeneshop
delete wantip
set status

- zoneedit1
delete wantip
set status

- easydns
delete wantipv*
set status (not status-ipv4/status-ipv6 !!!)
EDIT: Updated to set status-ipv4/status-ipv6 instead of status

- namecheap
delete wantip
set status

- nfsn
delete wantip
set status

- njalla
delete wantipv*
does not set status, mtime etc. (!!!)

- sitelutions
delete wantip
set status

- freedns
delete wantipv*
set status-ipv*

- 1984
delete wantip
does not set status, mtime etc. (!!!)

- changeip
delete wantip
set status

- godaddy
delete wantip
set "status"

- googledomains
delete wantip
set "status"

- mythicdyn
checks ipv6 (not wantipv6 !!!) only for v4 vs v6, service uses connection to determine IP
set "status"

- nsupdate
delete wantip
set ip, mtime, but not status

- cloudflare
delete wantipv*
set status-ipv*

- hetzner
delete wantipv*
set status-ipv*

- yandex
delete wantip
set status

- duckdns
delete wantip
set status

- freemyip
delete wantip
set status

- woima
delete wantip
set status

- dondominio
delete wantip
set status

- dnsmadeeasy
delete wantip
set status

- ovh
delete wantip
set status

- porkbun
delete wantipv*
set status (not status-ipv4/status-ipv6 !!!)
EDIT: Updated to set status-ipv4/status-ipv6 instead of status

- cloudns
delete wantip
set status

- dinahosting
delete wantip
set status

- gandi
delete wantip
set status

- keysystems
delete wantip
set status

- regfishde
delete wantip (twice, ipv6 looks broken!!!)
set status

- enom
delete wantip
set status

- digitalocean
delete wantipv*
set status-ipv*

- infomaniak
delete wantipv*
set status
set status-ipv*

</details>